### PR TITLE
Add troubleshooting entry in README for flake8 errors during jhbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Then, use `mujin_webstackclientpy_generategraphclient.py` to generate the conten
 ### Jhbuild fails due to flake8:
 If Jhbuild fails on building mujinwebstackclientpy due to a flake8 violation (most likely with a several hundred errors and warnings), this could be happening due to flake8 running a default configuration within a virtual environment.
 
-If this seems to be the case, you must delete the virutal environment for Jhbuild to use our flake8 configuration.
+If this seems to be the case, you can delete the virtual environment.
 ```bash
 # delete the virtual environment
 rm -rf ./.ve

--- a/README.md
+++ b/README.md
@@ -50,4 +50,15 @@ Then, use `mujin_webstackclientpy_generategraphclient.py` to generate the conten
 
 ```bash
 ./.ve/bin/python devbin/mujin_webstackclientpy_generategraphclient.py --url http://controller123 > python/mujinwebstackclient/controllergraphclient.py
-````
+```
+
+## Troubleshooting
+
+### Jhbuild fails due to flake8:
+If Jhbuild fails on building mujinwebstackclientpy due to a flake8 violation (most likely with a several hundred errors and warnings), this could be happening due to flake8 running a default configuration within a virtual environment.
+
+If this seems to be the case, you must delete the virutal environment for Jhbuild to use our flake8 configuration.
+```bash
+# delete the virtual environment
+rm -rf ./.ve
+```


### PR DESCRIPTION
Ran across a pitfall when trying to jhbuild after generating a new `controllergraphclient.py`. Added an entry describing some troubleshooting steps if anybody else comes across this situation.