### PR TITLE
Remove unused args from CreateCycleLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1 (2023-03-09)
+
+- Remove unused arguments `reporterControllerId` and `reporterDateCreated` from `CreateCycleLogs`.
+
 # 0.3.0 (2023-02-15)
 
 - Remove automatic query field generation for graphql api. These fields can be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 - Remove automatic query field generation for graphql api. These fields can be
   changed frequently causing the webstack client to be unusuable. Users of
-  graph api now nees to explicitly specify fields and subfields they are
+  graph api now need to explicitly specify fields and subfields they are
   interested in.
 
 
 # 0.2.0 (2022-12-01)
 
-- Regenerate graph client for sensorLInkName.
+- Regenerate graph client for sensorLinkName.
 
 
 # 0.1.3 (2023-01-18)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,7 @@
+# 0.3.1 (Simplify CreateCycleLogs)
+
+The arguments `reporterControllerId` and `reporterDateCreated` have been removed from `CreateCycleLogs`.
+
 # 0.1.2 (Bugfix for migration)
 
 The `scenepk` argument in `GetSceneSensorMapping` and `SetSceneSensorMapping` is required now.

--- a/python/mujinwebstackclient/version.py
+++ b/python/mujinwebstackclient/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 # Do not forget to update CHANGELOG.md
 

--- a/python/mujinwebstackclient/webstackclient.py
+++ b/python/mujinwebstackclient/webstackclient.py
@@ -650,11 +650,11 @@ class WebstackClient(object):
         params.update(kwargs)
         return self.ObjectsWrapper(self._webclient.APICall('GET', u'cycleLog/', fields=fields, timeout=timeout, params=params))
 
-    def CreateCycleLogs(self, cycleLogs, reporterControllerId=None, reporterDateCreated=None, fields=None, timeout=5):
+    def CreateCycleLogs(self, cycleLogs, fields=None, timeout=5):
+        """Creates cycle logs. If the `id` field matches a log entry in the database, the entry is overwritten.
+        """
         return self._webclient.APICall('POST', u'cycleLog/', data={
             'cycleLogs': cycleLogs,
-            'reporterControllerId': reporterControllerId,
-            'reporterDateCreated': reporterDateCreated,
         }, fields=fields, timeout=timeout)
 
     #


### PR DESCRIPTION
These arguments were not used anywhere in `webstack` or the rest of the code base.