### PR TITLE
Support HTTP over Unix domain socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.0 (2023-04-18)
+
+- Support HTTP over Unix domain socket via optional `unixEndpoint` argument.
+
+
 # 0.4.1 (2023-03-13)
 
 - Regenerate graph client for new module library APIs.

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -21,6 +21,7 @@ from requests import adapters as requests_adapters
 from . import _
 from . import json
 from . import APIServerError, WebstackClientError, ControllerGraphClientException
+from .unixsocketadapter import UnixSocketAdapter
 
 import logging
 log = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ class ControllerWebClientRaw(object):
     _isok = False  # Flag to stop
     _session = None  # Requests session object
 
-    def __init__(self, baseurl, username, password, locale=None, author=None, userAgent=None, additionalHeaders=None):
+    def __init__(self, baseurl, username, password, locale=None, author=None, userAgent=None, additionalHeaders=None, unixEndpoint=None):
         self._baseurl = baseurl
         self._username = username
         self._password = password
@@ -59,9 +60,13 @@ class ControllerWebClientRaw(object):
         self._headers['X-CSRFToken'] = 'csrftoken'
         self._session.cookies.set('csrftoken', self._headers['X-CSRFToken'], path='/')
 
-        # Add retry to deal with closed keep alive connections
-        self._session.mount('https://', requests_adapters.HTTPAdapter(max_retries=3))
-        self._session.mount('http://', requests_adapters.HTTPAdapter(max_retries=3))
+        if unixEndpoint is None:
+            # Add retry to deal with closed keep alive connections
+            self._session.mount('https://', requests_adapters.HTTPAdapter(max_retries=3))
+            self._session.mount('http://', requests_adapters.HTTPAdapter(max_retries=3))
+        else:
+            self._session.adapters.pop('https://', None)  # we don't use https with unix sockets
+            self._session.mount('http://', UnixSocketAdapter(unixEndpoint, max_retries=3))
 
         # Set locale headers
         self.SetLocale(locale)

--- a/python/mujinwebstackclient/unixsocketadapter.py
+++ b/python/mujinwebstackclient/unixsocketadapter.py
@@ -26,7 +26,8 @@ class UnixSocketHTTPConnection(HTTPConnection):
 
     def _new_conn(self):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(self.timeout)
+        if self.timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+            sock.settimeout(self.timeout)
         sock.connect(self._socketPath)
         return sock
 

--- a/python/mujinwebstackclient/unixsocketadapter.py
+++ b/python/mujinwebstackclient/unixsocketadapter.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) MUJIN Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+import socket
+
+from requests.adapters import HTTPAdapter
+from urllib3 import HTTPConnectionPool
+from urllib3.connection import HTTPConnection
+
+
+class UnixSocketHTTPConnection(HTTPConnection):
+    def __init__(self, socketPath, *args, **kwargs):
+        super(UnixSocketHTTPConnection, self).__init__(*args, **kwargs)
+
+        def create_connection(_, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None):
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            sock.connect(socketPath)
+            return sock
+
+        self._create_connection = create_connection
+
+
+class UnixSocketConnectionPool(HTTPConnectionPool):
+    def __init__(self, socketPath):
+        super(UnixSocketConnectionPool, self).__init__('127.0.0.1')
+        UnixSocketConnectionPool.ConnectionCls = functools.partial(UnixSocketHTTPConnection, socketPath)
+        self.__socketPath = socketPath
+
+    def __str__(self):
+        return '%s(path=%s)' % (type(self).__name__, self.__socketPath)
+
+
+class UnixSocketAdapter(HTTPAdapter):
+    def __init__(self, socketPath, *args, **kwargs):
+        super(UnixSocketAdapter, self).__init__(*args, **kwargs)
+        self.__pool = UnixSocketConnectionPool(socketPath)
+
+    def close(self):
+        self.__pool.close()
+        super(UnixSocketAdapter, self).close()
+
+    def get_connection(self, url, proxies=None):
+        assert not proxies, 'proxies not supported for socket'
+        return self.__pool

--- a/python/mujinwebstackclient/version.py
+++ b/python/mujinwebstackclient/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 
 # Do not forget to update CHANGELOG.md
 

--- a/python/mujinwebstackclient/webstackclient.py
+++ b/python/mujinwebstackclient/webstackclient.py
@@ -114,7 +114,7 @@ class WebstackClient(object):
     controllerIp = ''  # Hostname of the controller web server
     controllerPort = 80  # Port of the controller web server
 
-    def __init__(self, controllerurl='http://127.0.0.1', controllerusername='', controllerpassword='', author=None, userAgent=None, additionalHeaders=None):
+    def __init__(self, controllerurl='http://127.0.0.1', controllerusername='', controllerpassword='', author=None, userAgent=None, additionalHeaders=None, unixEndpoint=None):
         """Logs into the Mujin controller.
 
         Args:
@@ -149,7 +149,7 @@ class WebstackClient(object):
             'username': self.controllerusername,
             'locale': os.environ.get('LANG', ''),
         }
-        self._webclient = controllerwebclientraw.ControllerWebClientRaw(self.controllerurl, self.controllerusername, self.controllerpassword, author=author, userAgent=userAgent, additionalHeaders=additionalHeaders)
+        self._webclient = controllerwebclientraw.ControllerWebClientRaw(self.controllerurl, self.controllerusername, self.controllerpassword, author=author, userAgent=userAgent, additionalHeaders=additionalHeaders, unixEndpoint=unixEndpoint)
 
     def __del__(self):
         self.Destroy()

--- a/python/mujinwebstackclient/webstackclient.py
+++ b/python/mujinwebstackclient/webstackclient.py
@@ -122,7 +122,8 @@ class WebstackClient(object):
             controllerusername (str): Username of the mujin controller, e.g. testuser
             controllerpassword (str): Password of the mujin controller
             userAgent (str): User agent to be sent on each request
-            additionalHeaders: Additional HTTP headers to be included in requests
+            additionalHeaders (dict): Additional HTTP headers to be included in requests
+            unixEndpoint (str): Unix socket endpoint for communicating with HTTP server over unix socket
         """
 
         # Parse controllerurl


### PR DESCRIPTION
This PR adds support HTTP over Unix domain socket via optional `unixEndpoint` argument.

Behaves like `curl`: `curl --unix-socket /path/to/http.sock http://127.0.0.1/api/v1/`