### PR TITLE
Increase the default pool size for UnixSocketAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.1 (2023-06-28)
+
+- Set the default pool size to 10 for `UnixSocketConnectionPool`.
+
+
 # 0.5.0 (2023-04-18)
 
 - Support HTTP over Unix domain socket via optional `unixEndpoint` argument.

--- a/python/mujinwebstackclient/unixsocketadapter.py
+++ b/python/mujinwebstackclient/unixsocketadapter.py
@@ -40,8 +40,8 @@ class UnixSocketConnectionPool(HTTPConnectionPool):
 
     _unixEndpoint = None # unix socket endpoint
 
-    def __init__(self, unixEndpoint):
-        super(UnixSocketConnectionPool, self).__init__('127.0.0.1')
+    def __init__(self, unixEndpoint, maxSize=10):
+        super(UnixSocketConnectionPool, self).__init__('127.0.0.1', maxsize=maxSize)
         UnixSocketConnectionPool.ConnectionCls = functools.partial(UnixSocketHTTPConnection, unixEndpoint=unixEndpoint)
         self._unixEndpoint = unixEndpoint
 

--- a/python/mujinwebstackclient/version.py
+++ b/python/mujinwebstackclient/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 # Do not forget to update CHANGELOG.md
 


### PR DESCRIPTION
`requests.adapters.HTTPAdapter` internally overwrites the default pool size for `HTTPConnectionPool` and sets it to 10. 

However, `UnixSocketAdapter`  doesn't overwrite the default and the pool size stays at 1. I changed this.