### PR TITLE
Use MujinResourceIdentifier for GetPrimaryKeyFromURI 

### DIFF
--- a/python/mujinwebstackclient/uriutils.py
+++ b/python/mujinwebstackclient/uriutils.py
@@ -227,7 +227,7 @@ def GetFragmentFromURI(uri, **kwargs):
     """
     return MujinResourceIdentifier(uri=uri, **kwargs).fragment
 
-def GetPrimaryKeyFromURI(uri, **kwargs):
+def GetPrimaryKeyFromURI(uri, fragmentSeparator=FRAGMENT_SEPARATOR_AT, primaryKeySeparator=PRIMARY_KEY_SEPARATOR_AT, **kwargs):
     u"""
     input:
         uri: A mujin scheme uri which is utf-8 decoded unicode.
@@ -239,6 +239,8 @@ def GetPrimaryKeyFromURI(uri, **kwargs):
     >>> GetPrimaryKeyFromURI(u'mujin:/测试_test..mujin.dae@body0_motion', fragmentSeparator=FRAGMENT_SEPARATOR_SHARP)
     '%E6%B5%8B%E8%AF%95_test..mujin.dae%40body0_motion'
     """
+    kwargs['fragmentSeparator'] = fragmentSeparator
+    kwargs['primaryKeySeparator'] = primaryKeySeparator
     return MujinResourceIdentifier(uri=uri, **kwargs).primaryKey
 
 def GetPrimaryKeyFromFilename(filename, **kwargs):

--- a/python/mujinwebstackclient/uriutils.py
+++ b/python/mujinwebstackclient/uriutils.py
@@ -239,26 +239,7 @@ def GetPrimaryKeyFromURI(uri, fragmentSeparator=FRAGMENT_SEPARATOR_AT, primaryKe
     >>> GetPrimaryKeyFromURI(u'mujin:/测试_test..mujin.dae@body0_motion', fragmentSeparator=FRAGMENT_SEPARATOR_SHARP)
     '%E6%B5%8B%E8%AF%95_test..mujin.dae%40body0_motion'
     """
-    if uri is None or len(uri) == 0:
-        return EMPTY_STRING_UTF8
-    
-    scheme, netloc, path, params, query, fragment = _ParseURIFast(uri, fragmentSeparator)
-    #filename = EMPTY_STRING_UNICODE
-    if scheme == 'file':
-        # _mujinPath is empty...
-        #if os.path.commonprefix([self._mujinPath, parts.path]) != self._mujinPath:
-        #    raise URIError(_('scheme is file, but file absolute path is different from given mujinPath: %s') % uri)
-        filename = path#[len(self._mujinPath):]
-    elif scheme == 'mujin':
-        filename = path[1:]
-    else:
-        raise URIError(_('scheme %s isn\'t supported from uri %r') % (scheme, uri))
-    
-    primaryKey = _Quote(filename)
-    if fragment and primaryKeySeparator:
-        return primaryKey + primaryKeySeparator + _EnsureUTF8(fragment)
-    else:
-        return primaryKey
+    return MujinResourceIdentifier(uri=uri, **kwargs).primaryKey
 
 def GetPrimaryKeyFromFilename(filename, **kwargs):
     """ Extract primaryKey from filename .

--- a/python/mujinwebstackclient/uriutils.py
+++ b/python/mujinwebstackclient/uriutils.py
@@ -227,7 +227,7 @@ def GetFragmentFromURI(uri, **kwargs):
     """
     return MujinResourceIdentifier(uri=uri, **kwargs).fragment
 
-def GetPrimaryKeyFromURI(uri, fragmentSeparator=FRAGMENT_SEPARATOR_AT, primaryKeySeparator=PRIMARY_KEY_SEPARATOR_AT):
+def GetPrimaryKeyFromURI(uri, **kwargs):
     u"""
     input:
         uri: A mujin scheme uri which is utf-8 decoded unicode.


### PR DESCRIPTION
This PR uses `MujinResourceIdentifier` for GetPrimaryKeyFromURI.

Mainly, `MujinResourceIdentifier` has the exact same logic for this already, with the extra handle of empty schema, which is not in this part of code removed.

https://github.com/mujin/mujinwebstackclientpy/blob/e8d38374ca04d38e83333755a7c2ec9adbc32314/python/mujinwebstackclient/uriutils.py#L465-L481