### PR TITLE
Allow customizing headers in `CallGraphAPI` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.11 (2024-06-14)
+
+### Changes
+
+- Allow customizing headers in `CallGraphAPI` calls.
+
 ## 0.7.10 (2024-04-11)
 
 ### Changes

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -207,11 +207,15 @@ class ControllerWebClientRaw(object):
 
         return content
 
-    def CallGraphAPI(self, query, variables=None, timeout=5.0):
-        response = self.Request('POST', '/api/v2/graphql', headers={
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-        }, data=json.dumps({
+    def CallGraphAPI(self, query, variables=None, headers=None, timeout=5.0):
+        # prepare the headers
+        if headers is None:
+            headers = {}
+        headers['Content-Type'] = 'application/json'
+        headers['Accept'] = 'application/json'
+
+        # make the request
+        response = self.Request('POST', '/api/v2/graphql', headers=headers, data=json.dumps({
             'query': query,
             'variables': variables or {},
         }), timeout=timeout)

--- a/python/mujinwebstackclient/version.py
+++ b/python/mujinwebstackclient/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.10'
+__version__ = '0.7.11'
 
 # Do not forget to update CHANGELOG.md
 


### PR DESCRIPTION
Added `headers` argument to allow setting custom headers such as `X-Preserve-Modified-At` while making GraphQL calls.