### PR TITLE
Remove archive file suffix correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.7 (2025-03-27)
+
+### Changes
+
+- Remove suffixes from archive file correctly
+
 ## 0.8.6 (2025-02-06)
 
 ### Changes

--- a/bin/mujin_webstackclientpy_downloaddata.py
+++ b/bin/mujin_webstackclientpy_downloaddata.py
@@ -70,7 +70,7 @@ def _DownloadBackup(webClient, sceneList, timeout=600.0):
 
     # extract the response, use the name supplied by webstack
     archiveFilename = re.findall('filename=(.+)', response.headers['Content-Disposition'])[0].strip('"')
-    downloadDirectory = os.path.join(os.getcwd(), archiveFilename.rstrip('.tar.gz'))
+    downloadDirectory = os.path.join(os.getcwd(), archiveFilename.removesuffix('.tar.gz'))
     log.info('downloading and saving data to: %s', downloadDirectory)
     with tarfile.open(fileobj=response.raw, mode='r|gz') as tar:
         tar.extractall(path=downloadDirectory)

--- a/python/mujinwebstackclient/version.py
+++ b/python/mujinwebstackclient/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.8.6'
+__version__ = '0.8.7'
 
 # Do not forget to update CHANGELOG.md
 


### PR DESCRIPTION
Use correct method to remove suffix to prevent issue in string modification

![image](https://github.com/user-attachments/assets/0bb270cf-ac2a-480f-84e4-f0c7d478c624)