### PR TITLE
Deadlock condition in graphclient  on subscribe/unsubscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.33 (2026-05-11)
+
+- Removed a deadlock that occurred when unsubscribing from an active subscription while a background thread attempted to acquire a subscription lock already held by the main subscribing thread.
+
 ## 0.9.32 (2026-04-02)
 
 - Re-generate graph api.

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -602,7 +602,7 @@ class ControllerWebClientRaw(object):
             subscription.GetSubscriptionCallbackFunction()(error=error, response=None)
         self._subscriptions.clear()
 
-    def SubscribeGraphAPI(self, query: str, callbackFunction: Callable[[Optional[ControllerGraphClientException], Optional[dict]], None], variables: Optional[dict] = None) -> Subscription:
+    def SubscribeGraphAPI(self, query: str, callbackFunction: Callable[[Optional[ControllerGraphClientException], Optional[dict]], None], variables: Optional[dict] = None, timeout: float = 5.0) -> Subscription:
         """Subscribes to changes on Mujin controller.
 
         Args:
@@ -638,14 +638,14 @@ class ControllerWebClientRaw(object):
         try:
             # Wait for the subscribe outside _subscriptionLock to avoid deadlocking
             # with websocket callbacks that may acquire the same lock while resolving
-            future.result(timeout=5.0)
+            future.result(timeout=timeout)
         except Exception as e:
             raise ControllerGraphClientException(f'Failed to subscribe within timeout: {e}')
         with self._subscriptionLock:
             self._subscriptions[subscriptionId] = subscription
         return subscription
 
-    def UnsubscribeGraphAPI(self, subscription: Subscription):
+    def UnsubscribeGraphAPI(self, subscription: Subscription, timeout: float = 5.0):
         """Unsubscribes to Mujin controller.
 
         Args:
@@ -677,7 +677,7 @@ class ControllerWebClientRaw(object):
             future = self._backgroundThread.RunCoroutine(_Unsubscribe())
         try:
             # wait for the async result outside the lock
-            future.result(timeout=5.0)
+            future.result(timeout=timeout)
         except Exception as e:
             log.exception('timeout or error while unsubscribing: %s', e)
 

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -655,25 +655,39 @@ class ControllerWebClientRaw(object):
 
         async def _Unsubscribe():
             try:
-                # check if self._subscriptionIds has subscriptionId
-                if subscriptionId in self._subscriptions:
-                    await self._webSocket.send(
-                        json.dumps(
-                            {
-                                'id': subscriptionId,
-                                'type': 'stop',
-                            },
-                        ),
-                    )
-                    # remove subscription
-                    self._subscriptions.pop(subscriptionId, None)
-
-                # close the websocket connection if no more subscribers are left
-                if len(self._subscriptions) == 0:
-                    await self._CloseWebSocket()
+                await self._webSocket.send(
+                    json.dumps(
+                        {
+                            'id': subscriptionId,
+                            'type': 'stop',
+                        },
+                    ),
+                )
             except Exception as e:
                 log.exception('caught WebSocket exception: %s', e)
                 await self._StopAllSubscriptions(ControllerGraphClientException(_('Failed to unsubscribe: %s') % (e)))
+
+        with self._subscriptionLock:
+            if not self._IsWebSocketConnectionOpen():
+                return
+            # check if self._subscriptionIds has subscriptionId
+            if subscriptionId not in self._subscriptions:
+                return
+            # request unsubscribe under lock
+            future = self._backgroundThread.RunCoroutine(_Unsubscribe())
+        try:
+            # wait for the async result outside the lock
+            future.result(timeout=5.0)
+        except Exception as e:
+            log.exception('timeout or error while unsubscribing: %s', e)
+
+        # Re-acquire lock to safely modify the dictionary and check for shutdown
+        with self._subscriptionLock:
+            self._subscriptions.pop(subscriptionId, None)
+
+            # close the websocket connection if no more subscribers are left
+            if len(self._subscriptions) == 0 and self._IsWebSocketConnectionOpen():
+                self._backgroundThread.RunCoroutine(self._CloseWebSocket())
 
         with self._subscriptionLock:
             # nothing to do if websocket is not established

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -688,17 +688,3 @@ class ControllerWebClientRaw(object):
             # close the websocket connection if no more subscribers are left
             if len(self._subscriptions) == 0 and self._IsWebSocketConnectionOpen():
                 self._backgroundThread.RunCoroutine(self._CloseWebSocket())
-
-        with self._subscriptionLock:
-            # nothing to do if websocket is not established
-            if not self._IsWebSocketConnectionOpen():
-                return
-
-            # check if the subscription exists at all
-            if subscription.GetSubscriptionID() not in self._subscriptions:
-                return
-
-            # actually unsubscribe and wait until there is a result
-            future = self._backgroundThread.RunCoroutine(_Unsubscribe())
-        # Wait outside _subscriptionLock to avoid deadlocks with async unsubscribe handling
-        future.result(timeout=5.0)

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -634,10 +634,16 @@ class ControllerWebClientRaw(object):
             self._EnsureWebSocketConnection()
 
             # wait until the subscription is created
-            self._backgroundThread.RunCoroutine(_Subscribe()).result()
+            future = self._backgroundThread.RunCoroutine(_Subscribe())
+        try:
+            # Wait for the subscribe outside _subscriptionLock to avoid deadlocking
+            # with websocket callbacks that may acquire the same lock while resolving
+            future.result(timeout=5.0)
+        except Exception as e:
+            raise ControllerGraphClientException(f'Failed to subscribe within timeout: {e}')
+        with self._subscriptionLock:
             self._subscriptions[subscriptionId] = subscription
-
-            return subscription
+        return subscription
 
     def UnsubscribeGraphAPI(self, subscription: Subscription):
         """Unsubscribes to Mujin controller.
@@ -679,4 +685,6 @@ class ControllerWebClientRaw(object):
                 return
 
             # actually unsubscribe and wait until there is a result
-            self._backgroundThread.RunCoroutine(_Unsubscribe()).result()
+            future = self._backgroundThread.RunCoroutine(_Unsubscribe())
+        # Wait outside _subscriptionLock to avoid deadlocks with async unsubscribe handling
+        future.result(timeout=5.0)

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -636,7 +636,7 @@ class ControllerWebClientRaw(object):
             # wait until the subscription is created
             future = self._backgroundThread.RunCoroutine(_Subscribe())
         try:
-            # Wait for the subscribe outside _subscriptionLock to avoid deadlocking
+            # wait for the subscribe outside _subscriptionLock to avoid deadlocking
             # with websocket callbacks that may acquire the same lock while resolving
             future.result(timeout=timeout)
         except Exception as e:
@@ -668,6 +668,7 @@ class ControllerWebClientRaw(object):
                 await self._StopAllSubscriptions(ControllerGraphClientException(_('Failed to unsubscribe: %s') % (e)))
 
         with self._subscriptionLock:
+            # nothing to do if websocket is not established
             if not self._IsWebSocketConnectionOpen():
                 return
             # check if self._subscriptionIds has subscriptionId
@@ -681,7 +682,7 @@ class ControllerWebClientRaw(object):
         except Exception as e:
             log.exception('timeout or error while unsubscribing: %s', e)
 
-        # Re-acquire lock to safely modify the dictionary and check for shutdown
+        # re-acquire lock to safely modify the dictionary and check for shutdown
         with self._subscriptionLock:
             self._subscriptions.pop(subscriptionId, None)
 

--- a/python/mujinwebstackclient/version.py
+++ b/python/mujinwebstackclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.9.32'
+__version__ = '0.9.33'
 
 # Do not forget to update CHANGELOG.md


### PR DESCRIPTION
Found a deadlock condition when trying to unsubscribe using the client

1. Main thread enters `UnsubscribeGraphAPI` -> acquires `self._subscriptionLock`
  2. Main thread calls `self._backgroundThread.RunCoroutine(_Unsubscribe()).result()` - still holding `_subscriptionLock`. 

`.result()` blocks the main thread until the coroutine returns -> we are waiting for this under lock                                                                                                                             
  3. On the background thread's event loop, _Unsubscribe runs and reaches `await self._CloseWebSocket()` -> `await self._webSocket.close()`. That await yields control back to the event loop.                                                                                                                                   
  4. now yielded, the sleeping `_ListenToWebSocket` function wakes up because the websocket just 

  5. `_ListenToWebSocket` exception handler executes with self._subscriptionLock: - synchronous threading.Lock. The main thread holds it, so the background thread blocks here and freezes. The entire event loop is now blocked - no further awaits can move now
   
  7. `_Unsubscribe` `await self._webSocket.close()` never gets to return, so .result() on the main thread never completes. Main thread keeps holding `_subscriptionLock`. Stuck.
  
  Error on sigterm
 ```
2026-05-08 14:14:48,914 mujinwebstackclient.controllerwebclientraw [ERROR] [controllerwebclientraw.py:598 _ListenToWebSocket] caught WebSocket exception: sent 1000 (OK); no close frame received
Traceback (most recent call last):
  File "/opt/lib/python3.13/site-packages/mujinwebstackclient/controllerwebclientraw.py", line 539, in _ListenToWebSocket
    async for response in self._webSocket:
    ...<55 lines>...
            subscription.GetSubscriptionCallbackFunction()(error=None, response=content.get('payload') or {})
  File "/opt/lib/python3.13/site-packages/websockets/asyncio/connection.py", line 242, in __aiter__
    yield await self.recv()
          ^^^^^^^^^^^^^^^^^
  File "/opt/lib/python3.13/site-packages/websockets/asyncio/connection.py", line 322, in recv
    raise self.protocol.close_exc from self.recv_exc
websockets.exceptions.ConnectionClosedError: sent 1000 (OK); no close frame received
ConnectionClosedError(None, Close(code=1000, reason=''), None)
                         
```