### PR TITLE
feat: support backup and restore accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.37 (2026-07-07)
+
+- Support backup and restore accounts (users, groups, roles, permissions).
+
 ## 0.9.36 (2026-07-03)
 
 - Support backup and restore grafana monitoring resources.

--- a/python/mujinwebstackclient/version.py
+++ b/python/mujinwebstackclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.9.36'
+__version__ = '0.9.37'
 
 # Do not forget to update CHANGELOG.md

--- a/python/mujinwebstackclient/webstackclient.py
+++ b/python/mujinwebstackclient/webstackclient.py
@@ -1084,6 +1084,7 @@ class WebstackClient(object):
         saveiodd=True,
         savecalendar=True,
         savemonitoring=True,
+        saveaccounts=True,
         logentrytimerange=None,
         logentryids=None,
         logtypes=None,
@@ -1109,6 +1110,7 @@ class WebstackClient(object):
         :param saveiodd: Whether we want to include iodd files in the backup, defaults to True
         :param savecalendar: Whether we want to include the production calendar in the backup, defaults to True
         :param savemonitoring: Whether we want to include the grafana monitoring resources in the backup, defaults to True
+        :param saveaccounts: Whether we want to include the accounts (users, groups, roles, permissions) in the backup, defaults to True
         :param logentrytimerange: Timestamp range for backing up log entries, defaults to None
         :param logentryids: A list of log entry IDs for backing up log entries, defaults to None
         :param logtypes: A list of log entry types for backing up log entries, defaults to None
@@ -1139,6 +1141,7 @@ class WebstackClient(object):
                 'iodd': 'true' if saveiodd else 'false',
                 'calendar': 'true' if savecalendar else 'false',
                 'monitoring': 'true' if savemonitoring else 'false',
+                'accounts': 'true' if saveaccounts else 'false',
                 'logEntryTimeRange': logentrytimerange,
                 'logEntryIds': ','.join(logentryids) if logentryids else None,
                 'logTypes': ','.join(logtypes) if logtypes else None,
@@ -1166,6 +1169,7 @@ class WebstackClient(object):
         restoreiodd=True,
         restorecalendar=True,
         restoremonitoring=True,
+        restoreaccounts=True,
         archiveformat=None,
         timeout=600,
     ):
@@ -1180,6 +1184,7 @@ class WebstackClient(object):
         :param restoreiodd: Whether we want to restore the iodd files, defaults to True
         :param restorecalendar: Whether we want to restore the production calendar, defaults to True
         :param restoremonitoring: Whether we want to restore the grafana monitoring resources, defaults to True
+        :param restoreaccounts: Whether we want to restore the accounts (users, groups, roles, permissions), defaults to True
         :param archiveformat: The backup file archive format, supported values are tar.gz and zip, defaults to None
         :param timeout: Amount of time in seconds to wait before failing, defaults to 600
         :raises WebstackClientError: If request wasn't successful
@@ -1198,6 +1203,7 @@ class WebstackClient(object):
                 'iodd': 'true' if restoreiodd else 'false',
                 'calendar': 'true' if restorecalendar else 'false',
                 'monitoring': 'true' if restoremonitoring else 'false',
+                'accounts': 'true' if restoreaccounts else 'false',
                 'archiveFormat': archiveformat,
             },
             timeout=timeout,


### PR DESCRIPTION
Add `saveaccounts`/`restoreaccounts` parameters to `Backup` and `Restore`, sending the `accounts` query parameter to the webstack backup endpoint.

Pipeline #1998710


