### PR TITLE
Replace json/ujson with msgspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.38 (2026-07-31)
+
+- Use `msgspec` for all JSON encoding and decoding, replacing `json` and `ujson`.
+- Removed the `json` re-export from the `mujinwebstackclient` package. Import `msgspec` directly instead.
+- JSON decoding errors now raise `msgspec.DecodeError` instead of `ValueError`.
+
 ## 0.9.37 (2026-07-07)
 
 - Support backup and restore accounts (users, groups, roles, permissions).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## 0.9.38 (2026-07-31)
 
-- Use `msgspec` for all JSON encoding and decoding, replacing `json` and `ujson`.
+- Use `msgspec` for all JSON encoding and decoding, with a `ujson` fallback for types `msgspec` cannot serialize natively (such as `numpy` scalars and arrays), matching `mujinzmqclientpy` and `mujinplanningserver`.
 - Removed the `json` re-export from the `mujinwebstackclient` package. Import `msgspec` directly instead.
-- JSON decoding errors now raise `msgspec.DecodeError` instead of `ValueError`.
 
 ## 0.9.37 (2026-07-07)
 

--- a/bin/mujin_webstackclientpy_applyconfig.py
+++ b/bin/mujin_webstackclientpy_applyconfig.py
@@ -19,7 +19,7 @@ def _PrettifyConfig(config):
     return msgspec.json.format(msgspec.json.encode(config, order='sorted'), indent=2).decode('utf-8') + '\n'
 
 
-def _MergeDicts(x, y):  # for python 2 compatibility
+def _MergeDicts(x, y):
     z = copy.deepcopy(x)
     z.update(y)
     return z

--- a/bin/mujin_webstackclientpy_applyconfig.py
+++ b/bin/mujin_webstackclientpy_applyconfig.py
@@ -3,7 +3,7 @@
 
 import six
 import copy
-import json
+import msgspec
 import argparse
 import tempfile
 import subprocess
@@ -15,7 +15,8 @@ log = logging.getLogger(__name__)
 
 
 def _PrettifyConfig(config):
-    return json.dumps(config, ensure_ascii=False, indent=2, separators=(',', ': '), sort_keys=True) + '\n'
+    # msgspec only emits compact json, so indent it in a second pass
+    return msgspec.json.format(msgspec.json.encode(config, order='sorted'), indent=2).decode('utf-8') + '\n'
 
 
 def _MergeDicts(x, y):  # for python 2 compatibility
@@ -251,8 +252,8 @@ def _RunMain():
         logging.basicConfig(format='%(asctime)s %(name)s [%(levelname)s] [%(filename)s:%(lineno)s %(funcName)s] %(message)s', level=options.loglevel)
 
     # load template
-    with open(options.template, 'r') as f:
-        template = json.load(f)
+    with open(options.template, 'rb') as f:
+        template = msgspec.json.decode(f.read())
 
     # load preservelist
     preservedpaths = None
@@ -271,8 +272,8 @@ def _RunMain():
         config = webstackclient.GetConfig()
         target = webstackclient.controllerIp
     elif options.config:
-        with open(options.config, 'r') as f:
-            config = json.load(f)
+        with open(options.config, 'rb') as f:
+            config = msgspec.json.decode(f.read())
         target = options.config
     else:
         log.error('need to supply either --controller or --config to continue')

--- a/bin/mujin_webstackclientpy_runregistrationtask.py
+++ b/bin/mujin_webstackclientpy_runregistrationtask.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import json
+import msgspec
 import time
 import datetime
 import argparse
@@ -149,9 +149,10 @@ def _RunMain():
     # write result
     if not options.outputFilename:
         options.outputFilename = '%s.json' % taskName
-    with open(options.outputFilename, 'w') as f:
-        json.dump(result, f, ensure_ascii=False, indent=2, separators=(',', ': '), sort_keys=True)
-        f.write('\n')
+    with open(options.outputFilename, 'wb') as f:
+        # msgspec only emits compact json, so indent it in a second pass
+        f.write(msgspec.json.format(msgspec.json.encode(result, order='sorted'), indent=2))
+        f.write(b'\n')
     log.info('result written to: %s', options.outputFilename)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [project]
 name = "mujinwebstackclient"
 dependencies = [
-    "six~=1.16",
+    "msgspec~=0.19.0",
     "msgspec~=0.19.0",
     "requests~=2.32.2",
+    "six~=1.16",
     "typing_extensions~=4.2",
+    "ujson~=1.35",
     "websockets~=15.0",
 ]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "mujinwebstackclient"
 dependencies = [
     "six~=1.16",
+    "msgspec~=0.19.0",
     "requests~=2.32.2",
     "typing_extensions~=4.2",
     "websockets~=15.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [project]
 name = "mujinwebstackclient"
 dependencies = [
-    "msgspec~=0.19.0",
+    "six~=1.16",
     "msgspec~=0.19.0",
     "requests~=2.32.2",
-    "six~=1.16",
     "typing_extensions~=4.2",
     "ujson~=1.35",
     "websockets~=15.0",

--- a/python/mujinwebstackclient/__init__.py
+++ b/python/mujinwebstackclient/__init__.py
@@ -6,11 +6,6 @@ from .version import __version__  # noqa: F401
 import six
 
 try:
-    import ujson as json  # noqa: F401
-except ImportError:
-    import json  # noqa: F401
-
-try:
     from urllib import parse as urlparse  # noqa: F401
 except ImportError:
     import urlparse  # noqa: F401

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -275,8 +275,10 @@ class ControllerWebClientRaw(object):
         """Decodes a JSON response body, raising APIServerError rather than leaking msgspec.DecodeError."""
         try:
             return self._jsonDecoder.decode(data)
-        except msgspec.DecodeError as e:
-            raise APIServerError(_('Unable to parse server response: %s') % data) from e
+        except msgspec.DecodeError as error:
+            raw = data.decode('utf-8', 'replace') if isinstance(data, bytes) else data
+            log.exception('caught exception parsing json response: %s: %s', error, raw)
+            raise APIServerError(_('Unable to parse server response: %s') % raw[:1000]) from error
 
     def SetLocale(self, locale=None):
         locale = locale or os.environ.get('LANG', None)
@@ -401,11 +403,7 @@ class ControllerWebClientRaw(object):
         raw = response.content.decode('utf-8', 'replace').strip()
         content: Optional[Dict[str, Any]] = None
         if len(raw) > 0:
-            try:
-                content = self._jsonDecoder.decode(raw)
-            except msgspec.DecodeError as e:
-                log.exception('caught exception parsing json response: %s: %s', e, raw)
-                raise APIServerError(_('Unable to parse server response %d: %s') % (response.status_code, raw))
+            content = self.DecodeJSON(raw)
 
         # First check error
         if content is not None and 'error_message' in content:

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -193,7 +193,7 @@ class ControllerWebClientRaw(object):
         self._subscriptions = {}
         self._subscriptionLock = threading.Lock()
 
-        self._jsonEncoder = msgspec.json.Encoder(enc_hook=self._JsonEncodeHook)
+        self._jsonEncoder = msgspec.json.Encoder(enc_hook=self._JSONEncodeHook)
         self._jsonDecoder = msgspec.json.Decoder()
 
         # Create session
@@ -253,7 +253,7 @@ class ControllerWebClientRaw(object):
         self._isok = False
 
     @staticmethod
-    def _JsonEncodeHook(obj: Any) -> Any:
+    def _JSONEncodeHook(obj: Any) -> Any:
         # Convert numpy values to the native python objects that msgspec then re-encodes directly.
         # ujson only handles the numpy types that subclass a python builtin (float64, str_), and raises
         # OverflowError on the integer, boolean and narrow float types, so they cannot reach the fallback below.
@@ -267,16 +267,16 @@ class ControllerWebClientRaw(object):
         # Splice the encoded output via msgspec.Raw to avoid reprocessing the serialized result.
         return msgspec.Raw(ujson.dumps(obj).encode('utf-8'))
 
-    def EncodeJson(self, obj: Any) -> bytes:
+    def EncodeJSON(self, obj: Any) -> bytes:
         """Encodes an object into a JSON request body, tolerating types msgspec cannot serialize natively."""
         return self._jsonEncoder.encode(obj)
 
-    def DecodeJson(self, data: Union[str, bytes]) -> Any:
-        """Decodes a JSON response body, raising ValueError rather than leaking msgspec.DecodeError."""
+    def DecodeJSON(self, data: Union[str, bytes]) -> Any:
+        """Decodes a JSON response body, raising APIServerError rather than leaking msgspec.DecodeError."""
         try:
             return self._jsonDecoder.decode(data)
         except msgspec.DecodeError as e:
-            raise ValueError('Received invalid JSON string: %r' % data) from e
+            raise APIServerError(_('Unable to parse server response: %s') % data) from e
 
     def SetLocale(self, locale=None):
         locale = locale or os.environ.get('LANG', None)

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -20,6 +20,7 @@ import ssl
 import requests
 import threading
 import traceback
+import ujson
 import uuid
 import copy
 import websockets
@@ -30,6 +31,12 @@ from urllib.parse import urlparse
 
 import websockets.asyncio
 import websockets.asyncio.client
+
+# numpy is not a dependency of this client, but callers routinely pass numpy values in request bodies
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 from . import _
 from . import APIServerError, WebstackClientError, ControllerGraphClientException
@@ -160,6 +167,10 @@ class ControllerWebClientRaw(object):
 
     _threadName: Optional[str] = None  # The last thread this client was used in if we're warning on calls from different threads.
 
+    # Cached JSON decode/encode contexts
+    _jsonEncoder: msgspec.json.Encoder
+    _jsonDecoder: msgspec.json.Decoder
+
     def __init__(
         self,
         baseurl: str,
@@ -181,6 +192,9 @@ class ControllerWebClientRaw(object):
 
         self._subscriptions = {}
         self._subscriptionLock = threading.Lock()
+
+        self._jsonEncoder = msgspec.json.Encoder(enc_hook=self._JsonEncodeHook)
+        self._jsonDecoder = msgspec.json.Decoder()
 
         # Create session
         self._session = requests.Session()
@@ -237,6 +251,32 @@ class ControllerWebClientRaw(object):
 
     def SetDestroy(self):
         self._isok = False
+
+    @staticmethod
+    def _JsonEncodeHook(obj: Any) -> Any:
+        # Convert numpy values to the native python objects that msgspec then re-encodes directly.
+        # ujson only handles the numpy types that subclass a python builtin (float64, str_), and raises
+        # OverflowError on the integer, boolean and narrow float types, so they cannot reach the fallback below.
+        if numpy is not None:
+            if isinstance(obj, numpy.ndarray):
+                return obj.tolist()
+            if isinstance(obj, numpy.generic):
+                return obj.item()
+
+        # For other types, fall back to the ujson behaviour (inferring serialization based on members).
+        # Splice the encoded output via msgspec.Raw to avoid reprocessing the serialized result.
+        return msgspec.Raw(ujson.dumps(obj).encode('utf-8'))
+
+    def EncodeJson(self, obj: Any) -> bytes:
+        """Encodes an object into a JSON request body, tolerating types msgspec cannot serialize natively."""
+        return self._jsonEncoder.encode(obj)
+
+    def DecodeJson(self, data: Union[str, bytes]) -> Any:
+        """Decodes a JSON response body, raising ValueError rather than leaking msgspec.DecodeError."""
+        try:
+            return self._jsonDecoder.decode(data)
+        except msgspec.DecodeError as e:
+            raise ValueError('Received invalid JSON string: %r' % data) from e
 
     def SetLocale(self, locale=None):
         locale = locale or os.environ.get('LANG', None)
@@ -350,7 +390,7 @@ class ControllerWebClientRaw(object):
         # Default to json content type if not using multipart/form-data
         if 'Content-Type' not in headers and files is None and data is not None:
             headers['Content-Type'] = 'application/json'
-            data = msgspec.json.encode(data)
+            data = self._jsonEncoder.encode(data)
 
         if 'Accept' not in headers:
             headers['Accept'] = 'application/json'
@@ -362,7 +402,7 @@ class ControllerWebClientRaw(object):
         content: Optional[Dict[str, Any]] = None
         if len(raw) > 0:
             try:
-                content = msgspec.json.decode(raw)
+                content = self._jsonDecoder.decode(raw)
             except msgspec.DecodeError as e:
                 log.exception('caught exception parsing json response: %s: %s', e, raw)
                 raise APIServerError(_('Unable to parse server response %d: %s') % (response.status_code, raw))
@@ -413,7 +453,7 @@ class ControllerWebClientRaw(object):
             'POST',
             '/api/v2/graphql',
             headers=headers,
-            data=msgspec.json.encode(
+            data=self._jsonEncoder.encode(
                 {
                     'query': query,
                     'variables': variables or {},
@@ -434,7 +474,7 @@ class ControllerWebClientRaw(object):
         content: Optional[Dict[str, Any]] = None
         if len(raw) > 0:
             try:
-                content = msgspec.json.decode(raw)
+                content = self._jsonDecoder.decode(raw)
             except msgspec.DecodeError as e:
                 log.exception('caught exception parsing json response: %s: %s', e, raw)
 
@@ -528,7 +568,7 @@ class ControllerWebClientRaw(object):
         # text=True keeps this a text frame, as required by the graphql-ws subprotocol,
         # since websockets would otherwise send the encoded bytes as a binary frame
         await self._webSocket.send(
-            msgspec.json.encode(
+            self._jsonEncoder.encode(
                 {
                     'type': 'connection_init',
                     'payload': {
@@ -550,7 +590,7 @@ class ControllerWebClientRaw(object):
                 content = None
                 if len(response) > 0:
                     try:
-                        content = msgspec.json.decode(response)
+                        content = self._jsonDecoder.decode(response)
                     except msgspec.DecodeError as e:
                         log.exception('caught exception parsing json response: %s: %s', e, response)
 
@@ -630,7 +670,7 @@ class ControllerWebClientRaw(object):
                 }
                 if variables:
                     message['payload']['variables'] = variables
-                await self._webSocket.send(msgspec.json.encode(message), text=True)
+                await self._webSocket.send(self._jsonEncoder.encode(message), text=True)
             except Exception as e:
                 log.exception('caught WebSocket exception: %s', e)
                 await self._StopAllSubscriptions(ControllerGraphClientException(_('Failed to subscribe: %s') % (e)))
@@ -662,7 +702,7 @@ class ControllerWebClientRaw(object):
         async def _Unsubscribe():
             try:
                 await self._webSocket.send(
-                    msgspec.json.encode(
+                    self._jsonEncoder.encode(
                         {
                             'id': subscriptionId,
                             'type': 'stop',

--- a/python/mujinwebstackclient/controllerwebclientraw.py
+++ b/python/mujinwebstackclient/controllerwebclientraw.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import base64
+import msgspec
 import os
 import ssl
 import requests
@@ -31,7 +32,6 @@ import websockets.asyncio
 import websockets.asyncio.client
 
 from . import _
-from . import json
 from . import APIServerError, WebstackClientError, ControllerGraphClientException
 from .unixsocketadapter import UnixSocketAdapter
 
@@ -350,7 +350,7 @@ class ControllerWebClientRaw(object):
         # Default to json content type if not using multipart/form-data
         if 'Content-Type' not in headers and files is None and data is not None:
             headers['Content-Type'] = 'application/json'
-            data = json.dumps(data)
+            data = msgspec.json.encode(data)
 
         if 'Accept' not in headers:
             headers['Accept'] = 'application/json'
@@ -362,8 +362,8 @@ class ControllerWebClientRaw(object):
         content: Optional[Dict[str, Any]] = None
         if len(raw) > 0:
             try:
-                content = json.loads(raw)
-            except ValueError as e:
+                content = msgspec.json.decode(raw)
+            except msgspec.DecodeError as e:
                 log.exception('caught exception parsing json response: %s: %s', e, raw)
                 raise APIServerError(_('Unable to parse server response %d: %s') % (response.status_code, raw))
 
@@ -413,7 +413,7 @@ class ControllerWebClientRaw(object):
             'POST',
             '/api/v2/graphql',
             headers=headers,
-            data=json.dumps(
+            data=msgspec.json.encode(
                 {
                     'query': query,
                     'variables': variables or {},
@@ -434,8 +434,8 @@ class ControllerWebClientRaw(object):
         content: Optional[Dict[str, Any]] = None
         if len(raw) > 0:
             try:
-                content = json.loads(raw)
-            except ValueError as e:
+                content = msgspec.json.decode(raw)
+            except msgspec.DecodeError as e:
                 log.exception('caught exception parsing json response: %s: %s', e, raw)
 
         # raise any error returned
@@ -525,8 +525,10 @@ class ControllerWebClientRaw(object):
                 max_size=None,
             )
 
+        # text=True keeps this a text frame, as required by the graphql-ws subprotocol,
+        # since websockets would otherwise send the encoded bytes as a binary frame
         await self._webSocket.send(
-            json.dumps(
+            msgspec.json.encode(
                 {
                     'type': 'connection_init',
                     'payload': {
@@ -534,6 +536,7 @@ class ControllerWebClientRaw(object):
                     },
                 },
             ),
+            text=True,
         )
 
     async def _ListenToWebSocket(self):
@@ -547,8 +550,8 @@ class ControllerWebClientRaw(object):
                 content = None
                 if len(response) > 0:
                     try:
-                        content = json.loads(response)
-                    except ValueError as e:
+                        content = msgspec.json.decode(response)
+                    except msgspec.DecodeError as e:
                         log.exception('caught exception parsing json response: %s: %s', e, response)
 
                 # sanity checks
@@ -627,7 +630,7 @@ class ControllerWebClientRaw(object):
                 }
                 if variables:
                     message['payload']['variables'] = variables
-                await self._webSocket.send(json.dumps(message))
+                await self._webSocket.send(msgspec.json.encode(message), text=True)
             except Exception as e:
                 log.exception('caught WebSocket exception: %s', e)
                 await self._StopAllSubscriptions(ControllerGraphClientException(_('Failed to subscribe: %s') % (e)))
@@ -659,12 +662,13 @@ class ControllerWebClientRaw(object):
         async def _Unsubscribe():
             try:
                 await self._webSocket.send(
-                    json.dumps(
+                    msgspec.json.encode(
                         {
                             'id': subscriptionId,
                             'type': 'stop',
                         },
                     ),
+                    text=True,
                 )
             except Exception as e:
                 log.exception('caught WebSocket exception: %s', e)

--- a/python/mujinwebstackclient/version.py
+++ b/python/mujinwebstackclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.9.37'
+__version__ = '0.9.38'
 
 # Do not forget to update CHANGELOG.md

--- a/python/mujinwebstackclient/webstackclient.py
+++ b/python/mujinwebstackclient/webstackclient.py
@@ -10,7 +10,6 @@ import datetime
 import base64
 from email.utils import parsedate
 
-import msgspec
 import six
 from typing import List, Tuple, Any, Dict  # noqa: F401
 
@@ -679,7 +678,7 @@ class WebstackClient(object):
         # type: (List[Tuple[str, Any, Dict[str, bytes]]], float) -> Any
         files = []
         for logType, logEntry, attachments in logEntries:
-            files.append(('logEntry/%s' % logType, ('', msgspec.json.encode(logEntry), 'application/json')))
+            files.append(('logEntry/%s' % logType, ('', self._webclient.EncodeJson(logEntry), 'application/json')))
             if attachments is not None:
                 for attachmentName, attachmentData in six.iteritems(attachments):
                     files.append(('attachment', (attachmentName, attachmentData)))
@@ -728,7 +727,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/fileupload', files={'file': f}, data=data, timeout=timeout)
         if response.status_code in (200,):
             try:
-                return msgspec.json.decode(response.content)
+                return self._webclient.DecodeJson(response.content)
             except Exception as e:
                 log.exception('failed to upload file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -748,7 +747,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/fileupload', files=[('files', (filename, f)) for filename, f in files], timeout=timeout)
         if response.status_code in (200,):
             try:
-                return msgspec.json.decode(response.content)
+                return self._webclient.DecodeJson(response.content)
             except Exception as e:
                 log.exception('failed to upload files: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'))
@@ -757,7 +756,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/file/delete/', data={'filename': filename}, timeout=timeout)
         if response.status_code in (200,):
             try:
-                return msgspec.json.decode(response.content)['filename']
+                return self._webclient.DecodeJson(response.content)['filename']
             except Exception as e:
                 log.exception('failed to delete file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -766,7 +765,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/file/delete/', data={'filenames': filenames}, timeout=timeout)
         if response.status_code in (200,):
             try:
-                return msgspec.json.decode(response.content)['filenames']
+                return self._webclient.DecodeJson(response.content)['filenames']
             except Exception as e:
                 log.exception('failed to delete file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -775,7 +774,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/file/list/', params={'dirname': dirname}, timeout=timeout)
         if response.status_code in (200, 404):
             try:
-                return msgspec.json.decode(response.content)
+                return self._webclient.DecodeJson(response.content)
             except Exception as e:
                 log.exception('failed to delete file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -886,7 +885,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/log/user/%s/' % category, params=params, timeout=timeout)
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to retrieve user log, status code is %d') % response.status_code, response=response)
-        return msgspec.json.decode(response.content)
+        return self._webclient.DecodeJson(response.content)
 
     def DownloadSignalLog(self, limit=None, cursor=None, includecursor=False, forward=False, timeout=2):
         """Get the signal log from the controller.
@@ -918,14 +917,14 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/query/barcodes/', params={'barcodes': ','.join(barcodes)})
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to query scenes based on barcode, status code is %d') % response.status_code, response=response)
-        return msgspec.json.decode(response.content)
+        return self._webclient.DecodeJson(response.content)
 
     #
     # Report stats to registration controller
     #
 
     def ReportStats(self, data, timeout=5):
-        response = self._webclient.Request('POST', '/stats/', data=msgspec.json.encode(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
+        response = self._webclient.Request('POST', '/stats/', data=self._webclient.EncodeJson(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to upload stats, status code is %d') % response.status_code, response=response)
 
@@ -945,7 +944,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', path, timeout=timeout)
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to retrieve configuration from controller, status code is %d') % response.status_code, response=response)
-        return msgspec.json.decode(response.content)
+        return self._webclient.DecodeJson(response.content)
 
     def HeadConfig(self, filename, timeout=5):
         """Perform a HEAD operation on the given configuration filename to retrieve metadata.
@@ -971,7 +970,7 @@ class WebstackClient(object):
         path = '/config/'
         if filename:
             path = '/config/%s/' % filename
-        response = self._webclient.Request('PUT', path, data=msgspec.json.encode(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
+        response = self._webclient.Request('PUT', path, data=self._webclient.EncodeJson(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
         if response.status_code not in (200, 202):
             raise WebstackClientError(_('Failed to set configuration to controller, status code is %d') % response.status_code, response=response)
 
@@ -988,7 +987,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/systeminfo/')
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to retrieve system info from controller, status code is %d') % response.status_code, response=response)
-        return msgspec.json.decode(response.content)
+        return self._webclient.DecodeJson(response.content)
 
     #
     # Reference Object PKs.
@@ -1003,7 +1002,7 @@ class WebstackClient(object):
         response = self._webclient.Request(
             'POST',
             '/referenceobjectpks/add/',
-            data=msgspec.json.encode(
+            data=self._webclient.EncodeJson(
                 {
                     'scenepk': scenepk,
                     'referenceobjectpks': referenceobjectpks,
@@ -1025,7 +1024,7 @@ class WebstackClient(object):
         response = self._webclient.Request(
             'POST',
             '/referenceobjectpks/remove/',
-            data=msgspec.json.encode(
+            data=self._webclient.EncodeJson(
                 {
                     'scenepk': scenepk,
                     'referenceobjectpks': referenceobjectpks,
@@ -1210,7 +1209,7 @@ class WebstackClient(object):
         )
         if response.status_code in (200,):
             try:
-                return msgspec.json.decode(response.content)
+                return self._webclient.DecodeJson(response.content)
             except Exception as e:
                 log.exception('failed to restore: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -1264,4 +1263,4 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/schema/%s/%s.json' % (self._userinfo['locale'], schemaId))
         if response.status_code != 200:
             raise WebstackClientError(response.content.decode('utf-8'), response=response)
-        return msgspec.json.decode(response.content)
+        return self._webclient.DecodeJson(response.content)

--- a/python/mujinwebstackclient/webstackclient.py
+++ b/python/mujinwebstackclient/webstackclient.py
@@ -10,6 +10,7 @@ import datetime
 import base64
 from email.utils import parsedate
 
+import msgspec
 import six
 from typing import List, Tuple, Any, Dict  # noqa: F401
 
@@ -17,7 +18,6 @@ from typing import List, Tuple, Any, Dict  # noqa: F401
 from . import WebstackClientError
 from . import controllerwebclientraw
 from . import ugettext as _
-from . import json
 from . import urlparse
 from . import uriutils
 from . import webstackgraphclient
@@ -679,7 +679,7 @@ class WebstackClient(object):
         # type: (List[Tuple[str, Any, Dict[str, bytes]]], float) -> Any
         files = []
         for logType, logEntry, attachments in logEntries:
-            files.append(('logEntry/%s' % logType, ('', json.dumps(logEntry), 'application/json')))
+            files.append(('logEntry/%s' % logType, ('', msgspec.json.encode(logEntry), 'application/json')))
             if attachments is not None:
                 for attachmentName, attachmentData in six.iteritems(attachments):
                     files.append(('attachment', (attachmentName, attachmentData)))
@@ -728,7 +728,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/fileupload', files={'file': f}, data=data, timeout=timeout)
         if response.status_code in (200,):
             try:
-                return response.json()
+                return msgspec.json.decode(response.content)
             except Exception as e:
                 log.exception('failed to upload file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -748,7 +748,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/fileupload', files=[('files', (filename, f)) for filename, f in files], timeout=timeout)
         if response.status_code in (200,):
             try:
-                return response.json()
+                return msgspec.json.decode(response.content)
             except Exception as e:
                 log.exception('failed to upload files: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'))
@@ -757,7 +757,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/file/delete/', data={'filename': filename}, timeout=timeout)
         if response.status_code in (200,):
             try:
-                return response.json()['filename']
+                return msgspec.json.decode(response.content)['filename']
             except Exception as e:
                 log.exception('failed to delete file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -766,7 +766,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/file/delete/', data={'filenames': filenames}, timeout=timeout)
         if response.status_code in (200,):
             try:
-                return response.json()['filenames']
+                return msgspec.json.decode(response.content)['filenames']
             except Exception as e:
                 log.exception('failed to delete file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -775,7 +775,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/file/list/', params={'dirname': dirname}, timeout=timeout)
         if response.status_code in (200, 404):
             try:
-                return response.json()
+                return msgspec.json.decode(response.content)
             except Exception as e:
                 log.exception('failed to delete file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -886,7 +886,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/log/user/%s/' % category, params=params, timeout=timeout)
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to retrieve user log, status code is %d') % response.status_code, response=response)
-        return response.json()
+        return msgspec.json.decode(response.content)
 
     def DownloadSignalLog(self, limit=None, cursor=None, includecursor=False, forward=False, timeout=2):
         """Get the signal log from the controller.
@@ -918,14 +918,14 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/query/barcodes/', params={'barcodes': ','.join(barcodes)})
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to query scenes based on barcode, status code is %d') % response.status_code, response=response)
-        return response.json()
+        return msgspec.json.decode(response.content)
 
     #
     # Report stats to registration controller
     #
 
     def ReportStats(self, data, timeout=5):
-        response = self._webclient.Request('POST', '/stats/', data=json.dumps(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
+        response = self._webclient.Request('POST', '/stats/', data=msgspec.json.encode(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to upload stats, status code is %d') % response.status_code, response=response)
 
@@ -945,7 +945,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', path, timeout=timeout)
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to retrieve configuration from controller, status code is %d') % response.status_code, response=response)
-        return response.json()
+        return msgspec.json.decode(response.content)
 
     def HeadConfig(self, filename, timeout=5):
         """Perform a HEAD operation on the given configuration filename to retrieve metadata.
@@ -971,7 +971,7 @@ class WebstackClient(object):
         path = '/config/'
         if filename:
             path = '/config/%s/' % filename
-        response = self._webclient.Request('PUT', path, data=json.dumps(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
+        response = self._webclient.Request('PUT', path, data=msgspec.json.encode(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
         if response.status_code not in (200, 202):
             raise WebstackClientError(_('Failed to set configuration to controller, status code is %d') % response.status_code, response=response)
 
@@ -988,7 +988,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/systeminfo/')
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to retrieve system info from controller, status code is %d') % response.status_code, response=response)
-        return response.json()
+        return msgspec.json.decode(response.content)
 
     #
     # Reference Object PKs.
@@ -1003,7 +1003,7 @@ class WebstackClient(object):
         response = self._webclient.Request(
             'POST',
             '/referenceobjectpks/add/',
-            data=json.dumps(
+            data=msgspec.json.encode(
                 {
                     'scenepk': scenepk,
                     'referenceobjectpks': referenceobjectpks,
@@ -1025,7 +1025,7 @@ class WebstackClient(object):
         response = self._webclient.Request(
             'POST',
             '/referenceobjectpks/remove/',
-            data=json.dumps(
+            data=msgspec.json.encode(
                 {
                     'scenepk': scenepk,
                     'referenceobjectpks': referenceobjectpks,
@@ -1210,7 +1210,7 @@ class WebstackClient(object):
         )
         if response.status_code in (200,):
             try:
-                return response.json()
+                return msgspec.json.decode(response.content)
             except Exception as e:
                 log.exception('failed to restore: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -1264,4 +1264,4 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/schema/%s/%s.json' % (self._userinfo['locale'], schemaId))
         if response.status_code != 200:
             raise WebstackClientError(response.content.decode('utf-8'), response=response)
-        return response.json()
+        return msgspec.json.decode(response.content)

--- a/python/mujinwebstackclient/webstackclient.py
+++ b/python/mujinwebstackclient/webstackclient.py
@@ -678,7 +678,7 @@ class WebstackClient(object):
         # type: (List[Tuple[str, Any, Dict[str, bytes]]], float) -> Any
         files = []
         for logType, logEntry, attachments in logEntries:
-            files.append(('logEntry/%s' % logType, ('', self._webclient.EncodeJson(logEntry), 'application/json')))
+            files.append(('logEntry/%s' % logType, ('', self._webclient.EncodeJSON(logEntry), 'application/json')))
             if attachments is not None:
                 for attachmentName, attachmentData in six.iteritems(attachments):
                     files.append(('attachment', (attachmentName, attachmentData)))
@@ -727,7 +727,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/fileupload', files={'file': f}, data=data, timeout=timeout)
         if response.status_code in (200,):
             try:
-                return self._webclient.DecodeJson(response.content)
+                return self._webclient.DecodeJSON(response.content)
             except Exception as e:
                 log.exception('failed to upload file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -747,7 +747,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/fileupload', files=[('files', (filename, f)) for filename, f in files], timeout=timeout)
         if response.status_code in (200,):
             try:
-                return self._webclient.DecodeJson(response.content)
+                return self._webclient.DecodeJSON(response.content)
             except Exception as e:
                 log.exception('failed to upload files: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'))
@@ -756,7 +756,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/file/delete/', data={'filename': filename}, timeout=timeout)
         if response.status_code in (200,):
             try:
-                return self._webclient.DecodeJson(response.content)['filename']
+                return self._webclient.DecodeJSON(response.content)['filename']
             except Exception as e:
                 log.exception('failed to delete file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -765,7 +765,7 @@ class WebstackClient(object):
         response = self._webclient.Request('POST', '/file/delete/', data={'filenames': filenames}, timeout=timeout)
         if response.status_code in (200,):
             try:
-                return self._webclient.DecodeJson(response.content)['filenames']
+                return self._webclient.DecodeJSON(response.content)['filenames']
             except Exception as e:
                 log.exception('failed to delete file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -774,7 +774,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/file/list/', params={'dirname': dirname}, timeout=timeout)
         if response.status_code in (200, 404):
             try:
-                return self._webclient.DecodeJson(response.content)
+                return self._webclient.DecodeJSON(response.content)
             except Exception as e:
                 log.exception('failed to delete file: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -885,7 +885,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/log/user/%s/' % category, params=params, timeout=timeout)
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to retrieve user log, status code is %d') % response.status_code, response=response)
-        return self._webclient.DecodeJson(response.content)
+        return self._webclient.DecodeJSON(response.content)
 
     def DownloadSignalLog(self, limit=None, cursor=None, includecursor=False, forward=False, timeout=2):
         """Get the signal log from the controller.
@@ -917,14 +917,14 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/query/barcodes/', params={'barcodes': ','.join(barcodes)})
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to query scenes based on barcode, status code is %d') % response.status_code, response=response)
-        return self._webclient.DecodeJson(response.content)
+        return self._webclient.DecodeJSON(response.content)
 
     #
     # Report stats to registration controller
     #
 
     def ReportStats(self, data, timeout=5):
-        response = self._webclient.Request('POST', '/stats/', data=self._webclient.EncodeJson(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
+        response = self._webclient.Request('POST', '/stats/', data=self._webclient.EncodeJSON(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to upload stats, status code is %d') % response.status_code, response=response)
 
@@ -944,7 +944,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', path, timeout=timeout)
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to retrieve configuration from controller, status code is %d') % response.status_code, response=response)
-        return self._webclient.DecodeJson(response.content)
+        return self._webclient.DecodeJSON(response.content)
 
     def HeadConfig(self, filename, timeout=5):
         """Perform a HEAD operation on the given configuration filename to retrieve metadata.
@@ -970,7 +970,7 @@ class WebstackClient(object):
         path = '/config/'
         if filename:
             path = '/config/%s/' % filename
-        response = self._webclient.Request('PUT', path, data=self._webclient.EncodeJson(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
+        response = self._webclient.Request('PUT', path, data=self._webclient.EncodeJSON(data), headers={'Content-Type': 'application/json'}, timeout=timeout)
         if response.status_code not in (200, 202):
             raise WebstackClientError(_('Failed to set configuration to controller, status code is %d') % response.status_code, response=response)
 
@@ -987,7 +987,7 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/systeminfo/')
         if response.status_code != 200:
             raise WebstackClientError(_('Failed to retrieve system info from controller, status code is %d') % response.status_code, response=response)
-        return self._webclient.DecodeJson(response.content)
+        return self._webclient.DecodeJSON(response.content)
 
     #
     # Reference Object PKs.
@@ -1002,7 +1002,7 @@ class WebstackClient(object):
         response = self._webclient.Request(
             'POST',
             '/referenceobjectpks/add/',
-            data=self._webclient.EncodeJson(
+            data=self._webclient.EncodeJSON(
                 {
                     'scenepk': scenepk,
                     'referenceobjectpks': referenceobjectpks,
@@ -1024,7 +1024,7 @@ class WebstackClient(object):
         response = self._webclient.Request(
             'POST',
             '/referenceobjectpks/remove/',
-            data=self._webclient.EncodeJson(
+            data=self._webclient.EncodeJSON(
                 {
                     'scenepk': scenepk,
                     'referenceobjectpks': referenceobjectpks,
@@ -1209,7 +1209,7 @@ class WebstackClient(object):
         )
         if response.status_code in (200,):
             try:
-                return self._webclient.DecodeJson(response.content)
+                return self._webclient.DecodeJSON(response.content)
             except Exception as e:
                 log.exception('failed to restore: %s', e)
         raise WebstackClientError(response.content.decode('utf-8'), response=response)
@@ -1263,4 +1263,4 @@ class WebstackClient(object):
         response = self._webclient.Request('GET', '/schema/%s/%s.json' % (self._userinfo['locale'], schemaId))
         if response.status_code != 200:
             raise WebstackClientError(response.content.decode('utf-8'), response=response)
-        return self._webclient.DecodeJson(response.content)
+        return self._webclient.DecodeJSON(response.content)


### PR DESCRIPTION
Replace json/ujson usage with msgspec for performance.

In the event that types are not serializable with msgspec, the custom encoder hook will fall back to using ujson for those specific types.